### PR TITLE
allow changing Content-Type during CopyObject

### DIFF
--- a/config.js
+++ b/config.js
@@ -343,6 +343,12 @@ function extrasContentLength(options, args) {
     options.headers['Content-Length'] = args.ContentLength || Buffer.byteLength( options.body );
 }
 
+function extrasContentType(options, args) {
+    if (args.ContentType) {
+        options.headers['Content-Type'] = args.ContentType;
+    }
+}
+
 function extrasContentMd5(options, args) {
     var self = this;
 
@@ -1839,7 +1845,7 @@ module.exports = {
                 note     : 'A comma-separated list of one or more grantees (of the format type=value). Type must be emailAddress, id or url.',
             },
         },
-        addExtras : extrasCopySource,
+        addExtras : [extrasCopySource, extrasContentType],
     },
 
     InitiateMultipartUpload : {

--- a/examples/CopyObject-01-Basic.js
+++ b/examples/CopyObject-01-Basic.js
@@ -1,0 +1,39 @@
+//var dump = require('./dump.js');
+var amazonS3 = require('../awssum-amazon-s3.js');
+
+var s3 = new amazonS3.S3({
+    'accessKeyId'     : process.env.ACCESS_KEY_ID,
+    'secretAccessKey' : process.env.SECRET_ACCESS_KEY,
+    'region'          : amazonS3.US_EAST_1
+});
+
+var content = 'Hello, World!';
+var putArgs = {
+    BucketName    : process.env.BUCKET_NAME || 'pie-17',
+    ObjectName    : 'hello-world.txt',
+    ContentLength : content.length,
+    Body          : content
+};
+
+var copyArgs = {
+    BucketName:         putArgs.BucketName,
+    ContentType:        'text/plain',
+    MetadataDirective:  'REPLACE',
+    ObjectName:         putArgs.ObjectName,
+    SourceBucket:       putArgs.BucketName,
+    SourceObject:       putArgs.ObjectName
+};
+
+s3.PutObject(putArgs, function(err, data) {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    s3.CopyObject(copyArgs, function (err, data) {
+        if (err) {
+            console.error(err);
+        } else {
+            console.log(data);
+        }
+    });
+});


### PR DESCRIPTION
Needed this to fix the default `Content-Type` of `application/octet-stream` on some of my objects and could not see a way to make it work without this change. Added an example and manually tested that it works. Also FYI the `dump.js` module seems to be missing from the git repository so the examples don't work.
