### PR TITLE
    Allow the specification of custom endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,32 @@ s3.ListBuckets(function(err, data) {
 });
 ```
 
+## Support for third party services supporting AWS S3 API
+
+Support for third party services supporting AWS S3 API was introduced in version 1.3.2
+
+```
+dependencies : {
+    "awssum-amazon-s3" : "> 1.4.0",
+},
+```
+
+### Example ##
+
+```
+var amazonS3 = require('awssum-amazon-s3');
+
+var S3 = new amazonS3.S3({
+    'accessKeyId'     : process.env.ACCESS_KEY_ID,
+    'secretAccessKey' : process.env.SECRET_ACCESS_KEY,
+    'region'          : 'myregion',
+    'endPoint'        : { 'region' : 'myregion',
+                          'locationConstraint' : '',
+                          'endpoint' : {'protocol' : 'http', 'host' : 'localhost', 'port' : 8123, 'path' : '/path/to/service'}
+                        }
+});
+```
+
 ## Streaming ##
 
 Streaming uploads:

--- a/awssum-amazon-s3.js
+++ b/awssum-amazon-s3.js
@@ -91,6 +91,19 @@ var validSubresource = {
 var S3 = function(opts) {
     var self = this;
 
+    if (! _.isEmpty(opts.endPoint) ) {
+      if (_.isObject(opts.endPoint)) {
+          if (!  opts.endPoint.region) {
+              throw MARK + "region not defined";
+          }
+          if (!  opts.endPoint.endpoint.host) {
+              throw MARK + "host not defined for region'"+ opts.endPoint.region +"'";
+          }
+          endPoint[opts.endPoint.region] = opts.endPoint.endpoint;
+          locationConstraint[opts.endPoint.region] = opts.endPoint.locationConstraint || opts.endPoint.region;
+      }
+    }
+
     // call the superclass for initialisation
     S3.super_.call(this, opts);
 
@@ -108,8 +121,21 @@ util.inherits(S3, amazon.Amazon);
 // --------------------------------------------------------------------------------------------------------------------
 // methods we need to implement from awssum.js/amazon.js
 
+S3.prototype.protocol = function() {
+    return endPoint[this.region()].protocol || "https";
+};
+
 S3.prototype.host = function() {
-    return endPoint[this.region()];
+    return endPoint[this.region()].host || endPoint[this.region()];
+};
+
+S3.prototype.port = function() {
+    var self = this;
+    return endPoint[this.region()].port || ((self.protocol() === 'http') ? 80 : 443);
+};
+
+S3.prototype.path = function() {
+    return endPoint[this.region()].path || "/";
 };
 
 S3.prototype.version = function() {

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -1,0 +1,49 @@
+// --------------------------------------------------------------------------------------------------------------------
+//
+// require.js
+//
+// Written by Giannis Kosmas <kosmasgiannis@gmail.com>
+//
+// License: http://opensource.org/licenses/MIT
+//
+// --------------------------------------------------------------------------------------------------------------------
+// requires
+
+var fs = require('fs');
+var tap = require("tap");
+
+var test = tap.test;
+
+// local
+var amazonS3 = require('../awssum-amazon-s3.js');
+var S3 = amazonS3.S3;
+
+var FAKE_ACCESS_KEY_ID = 'WHATEVER';
+var FAKE_SECRET_ACCESS_KEY = 'WHATEVER';
+// --------------------------------------------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------------------------------------------
+
+test('Custom endpoint', function(t) {
+
+    var s3 = new S3({
+        'accessKeyId'     : FAKE_ACCESS_KEY_ID,
+        'secretAccessKey' : FAKE_SECRET_ACCESS_KEY,
+        'region'          : 'myregion',
+        'endPoint'        : { 'region' : 'myregion',
+                              'locationConstraint' : '',
+                              'endpoint' : {'protocol' : 'http', 'host' : 'localhost', 'port' : 8123, 'path' : '/path/to/service'}
+                            }
+    });
+
+    t.ok(s3, 'S3 instance created');
+    t.equal('myregion', s3.region(), 'Region set');
+    t.equal('http', s3.protocol(), 'Endpoint protocol set');
+    t.equal('localhost', s3.host(), 'Endpoint host set');
+    t.equal(8123, s3.port(), 'Endpoint port set');
+    t.equal('/path/to/service', s3.path(), 'Endpoint path set');
+
+    t.end();
+});
+
+// --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
```
This adds support for third party services supporting AWS EC2 API,
like OpenStack, Ceph etc.
```
